### PR TITLE
Remove deprecated std-ci/jenkins automations

### DIFF
--- a/automation/build-artifacts.packages
+++ b/automation/build-artifacts.packages
@@ -1,1 +1,0 @@
-build.packages

--- a/automation/build-artifacts.repos
+++ b/automation/build-artifacts.repos
@@ -1,1 +1,0 @@
-build.repos

--- a/automation/build-artifacts.sh
+++ b/automation/build-artifacts.sh
@@ -1,1 +1,0 @@
-build.sh

--- a/automation/build.packages
+++ b/automation/build.packages
@@ -1,6 +1,0 @@
-git
-jq
-wget
-rpmlint
-nodejs
-ovirt-engine-nodejs-modules

--- a/automation/build.repos
+++ b/automation/build.repos
@@ -1,5 +1,0 @@
-# for ovirt-engine-nodejs-modules for cache prefill
-ovirt-tested,https://resources.ovirt.org/repos/ovirt/tested/master/rpm/$distro/
-
-# include the jenkins repo in case the tested repo doesn't have the built rpm
-ovirt-engine-nodejs-modules_master,https://jenkins.ovirt.org/job/ovirt-engine-nodejs-modules_standard-on-merge/lastSuccessfulBuild/artifact/build-artifacts.$distro.x86_64

--- a/automation/check-merged.packages
+++ b/automation/check-merged.packages
@@ -1,1 +1,0 @@
-check.packages

--- a/automation/check-merged.sh
+++ b/automation/check-merged.sh
@@ -1,1 +1,0 @@
-check.sh

--- a/automation/check-patch.packages
+++ b/automation/check-patch.packages
@@ -1,1 +1,0 @@
-check.packages

--- a/automation/check-patch.sh
+++ b/automation/check-patch.sh
@@ -1,1 +1,0 @@
-check.sh

--- a/automation/check.packages
+++ b/automation/check.packages
@@ -1,5 +1,0 @@
-git
-jq
-wget
-rpmlint
-nodejs

--- a/ovirt-engine-nodejs-modules.spec
+++ b/ovirt-engine-nodejs-modules.spec
@@ -1,6 +1,6 @@
 Name: ovirt-engine-nodejs-modules
 Version: 2.2.0
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Node.js modules required to build oVirt JavaScript applications
 Group: Virtualization/Management
 License: Multiple
@@ -42,6 +42,9 @@ install -m 755 `find . -maxdepth 1 -name 'yarn-*.js' -exec basename {} \;` %{des
 %{_datadir}/%{name}
 
 %changelog
+* Wed Feb 2 2022 Scott J Dickerson <sdickers@redhat.com> - 2.2.0-2
+  - Remove deprecated std-ci/jenkins automations
+
 * Wed Feb 2 2022 Scott J Dickerson <sdickers@redhat.com> - 2.2.0-1
   - Migrate repo off gerrit to github
   - Update check action to consider all commits in a PR when verifying a change

--- a/stdci.yaml
+++ b/stdci.yaml
@@ -1,4 +1,0 @@
-distros:
-  - el8
-release_branches:
-  master: ["ovirt-master", "ovirt-4.4"]


### PR DESCRIPTION
  - Remove `stdci.yaml` and related `automation/*.packages`, `automation/*.repos` and `automation/*.sh` files.  Without the base yaml file, std-ci won't attempt to run anything.

  - Github actions take over PR CI testing and builds

  - copr provides builds from the master branch (https://copr.fedorainfracloud.org/coprs/ovirt/ovirt-master-snapshot/)

  - `automation/build.sh` and `automation/check.sh` are retained to handle the github automation work

Change-Id: Ia36c626f7f85db34eaea0fa9e44a52af7185f418
Signed-off-by: Scott J Dickerson <sdickers@redhat.com>