### PR TITLE
Add a manual run github action to create RPMs for a PR

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -5,17 +5,20 @@ on:
 jobs:
   test_el8:
     name: run check.sh to verify content
+
     runs-on: ubuntu-latest
     container:
-      image: quay.io/centos/centos:stream8
+      image: quay.io/ovirt/buildcontainer:el8stream
+
+    env:
+      # The check version script needs to know the PR base and head commits to be able to
+      # look at the contents of the range of commits for the PR. The required spec file
+      # change must be contained somewhere in one of those commits!  This env var will
+      # be picked up by the script and used as the range.
+      CHECK_RANGE: ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}
 
     steps:
-      - name: enable repos and choose module versions
-        run: |
-          dnf -y copr enable ovirt/ovirt-master-snapshot centos-stream-8
-          dnf -y module enable nodejs:14
-
-      - name: install check.sh required packages
+      - name: make sure check.sh required packages are installed
         run: |
           dnf -y install git jq wget rpmlint
 
@@ -26,9 +29,6 @@ jobs:
           fetch-depth: 20
           ref: ${{ github.event.pull_request.head.sha }}
 
-      # The script needs to know the PR base and head commits to be able to look at the
-      # contents of the range of commits for the PR. The required spec file must be updated
-      # somewhere in one of those commits!
       - name: run automation/check.sh
         run: |
-          ./automation/check.sh ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}
+          ./automation/check.sh

--- a/.github/workflows/comment-to-build-pr.yaml
+++ b/.github/workflows/comment-to-build-pr.yaml
@@ -1,0 +1,71 @@
+name: comment '/build rpm' to build a PR (the copr way)
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  build_el8:
+    name: build the rpm repo
+    if: |
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/build rpm') &&
+      (
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'COLLABORATOR' ||
+        github.event.comment.author_association == 'OWNER'
+      )
+
+    runs-on: ubuntu-latest
+    container:
+      image: quay.io/ovirt/buildcontainer:el8stream
+
+    env:
+      CHECK_VERSION: no
+      PR_NUMBER: ${{ github.event.issue.number }}
+
+    steps:
+      - name: make sure the action and build.sh required packages are installed
+        run: |
+          dnf -y config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
+          dnf -y install gh
+          dnf -y install git jq wget rpmlint rpm-build nodejs ovirt-engine-nodejs-modules
+
+      - name: checkout the repo
+        uses: actions/checkout@v2
+
+      - name: checkout the PR
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr checkout --repo ${GITHUB_REPOSITORY} ${PR_NUMBER}
+
+      - name: build src.rpm
+        run: ./automation/build.sh copr
+
+      - name: install build dependencies from src.rpm
+        run: |
+          dnf -y builddep exported-artifacts/ovirt-engine-nodejs-modules*.src.rpm
+
+      - name: Build rpm directly from src.rpm
+        run: |
+          rpmbuild \
+            --define="_rpmdir `pwd`/exported-artifacts" \
+            --rebuild exported-artifacts/ovirt-engine-nodejs-modules*.src.rpm
+
+      - name: upload artifacts
+        uses: ovirt/upload-rpms-action@v2
+        with:
+          directory: exported-artifacts/
+
+      - name: add success comment with a link to the action's run
+        if: success()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          LINK=$( \
+            gh api -X GET \
+              repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID} \
+              -q '"[action run summary]("+ .html_url +")"' \
+          )
+          echo ":heavy_check_mark: Build success! See the results and artifacts at $LINK." \
+            | gh pr comment --repo ${GITHUB_REPOSITORY} -F - ${PR_NUMBER}

--- a/automation/build.sh
+++ b/automation/build.sh
@@ -4,8 +4,10 @@
 artifacts_dir="${PWD}/exported-artifacts"
 rm -rf "${artifacts_dir}" && mkdir -p "${artifacts_dir}"
 
-# Make sure we remember to update the version and/or release:
-./automation/check-version-release.sh
+# If the build should check commits for version updates (e.g. if building a PR branch):
+if [[ "${CHECK_VERSION:-no}" == "yes" ]] ; then
+    ./automation/check-version-release.sh
+fi
 
 which node
 node --version

--- a/automation/check-version-release.sh
+++ b/automation/check-version-release.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -ex
 
-if ! git show $1 -- *.spec | \
+if ! git show ${CHECK_RANGE:-HEAD} -- *.spec | \
     grep '^+\(Version:\|Release:\)'
 then
     echo "Package version or release must be updated"

--- a/automation/check.sh
+++ b/automation/check.sh
@@ -1,11 +1,7 @@
 #!/bin/bash -e
 
 # Make sure we remember to update the version and/or release:
-if [[ "${1}" == "" ]] ; then
-    ./automation/check-version-release.sh HEAD
-else
-    ./automation/check-version-release.sh $1
-fi
+./automation/check-version-release.sh
 
 # Make sure we only have 1 instance of yarn
 [[ $(ls -1 yarn-*.js | wc -l) -ne 1 ]] && { echo "Error: multiple yarn binaries present"; exit 5; }

--- a/ovirt-engine-nodejs-modules.spec
+++ b/ovirt-engine-nodejs-modules.spec
@@ -1,6 +1,6 @@
 Name: ovirt-engine-nodejs-modules
 Version: 2.2.0
-Release: 3%{?dist}
+Release: 4%{?dist}
 Summary: Node.js modules required to build oVirt JavaScript applications
 Group: Virtualization/Management
 License: Multiple
@@ -49,6 +49,10 @@ install -m 755 `find . -maxdepth 1 -name 'yarn-*.js' -exec basename {} \;` %{des
 %{_datadir}/%{name}
 
 %changelog
+* Thu Feb 3 2022 Scott J Dickerson <sdickers@redhat.com> - 2.2.0-4
+  - Use quay.io/ovirt/buildcontainer:el8stream for github action builds
+  - Add a manual run github action to create RPMs for a PR
+
 * Thu Feb 3 2022 Scott J Dickerson <sdickers@redhat.com> - 2.2.0-3
   - Add BuildRequires for running automation/*.sh scripts in ovirt's build container
 


### PR DESCRIPTION
To support the use case of testing a rpm for changes in a specific PR, add a github action that runs when a comment "/build rpm" is created on a PR.

When the build is completed successfully, a comment with a link to the build action's summary is added for easy access.  The rpm repo can be downloaded from the link.

This action will run the build in the same way as copr runs a build:
  - setup the container (packages, sources)
  - create the source rpm
  - install any build requirements for the source rpm
  - build the rpm from the source rpm
  - publish a rpm repo of the results

Action "check the PR" has been updated to specify the PR commit range as an env var.  This let the check.sh and build.sh scripts and actions work together better.

**Note**: This PR currently includes the commits from PR #15.  That PR should be merged before this one.
