### PR TITLE
setup-env: update yarn command line

### DIFF
--- a/ovirt-engine-nodejs-modules.spec
+++ b/ovirt-engine-nodejs-modules.spec
@@ -1,6 +1,6 @@
 Name: ovirt-engine-nodejs-modules
 Version: 2.2.3
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Node.js modules required to build oVirt JavaScript applications
 Group: Virtualization/Management
 License: Multiple
@@ -49,6 +49,9 @@ install -m 755 `find . -maxdepth 1 -name 'yarn-*.js' -exec basename {} \;` %{des
 %{_datadir}/%{name}
 
 %changelog
+* Thu Apr 07 2022 Sandro Bonazzola <sbonazzo@redhat.com> - 2.2.3-2
+- update setup-env usage of yarn command line for https://github.com/oVirt/cockpit-ovirt/issues/23
+
 * Tue Mar 29 2022 Sharon Gratch <sgratch@redhat.com> - 2.2.3-1
   - Add pre-seed for https://github.com/oVirt/ovirt-engine-ui-extensions/pull/46
   - Remove pre-seed for https://github.com/oVirt/ovirt-engine-ui-extensions/pull/27

--- a/setup-env.sh.in
+++ b/setup-env.sh.in
@@ -14,14 +14,11 @@ export PATH="/usr/share/ovirt-engine-nodejs-modules/bin:${PATH}"
 # the "ovirt-engine-nodejs-modules" package:
 yarn config set yarn-offline-mirror "/usr/share/ovirt-engine-nodejs-modules/yarn-offline-cache"
 
-# Populate the "./node_modules" directory using Yarn:
-yarn install --offline --pure-lockfile
-
-# Verify that dependency versions (semantic version ranges)
+# Populate the "./node_modules" directory using Yarn and
+# verify that dependency versions (semantic version ranges)
 # in the "package.json" file have matching resolutions in
 # the "yarn.lock" file:
-# Let's ignore errors because the command is buggy anyway (https://classic.yarnpkg.com/en/docs/cli/check/)
-yarn check || /bin/true
+yarn install --offline --pure-lockfile --check-files
 
 # JavaScript modules put their executables (if any) into
 # the "./node_modules/.bin" directory, make sure it's on


### PR DESCRIPTION
using `yarn install --offline --pure-lockfile --check-files`
instead of
```
yarn install --offline --pure-lockfile
yarn check
```

as suggested by @fitiskin  in https://github.com/oVirt/cockpit-ovirt/issues/23
for solving build issues on CentOS Stream 9.

Signed-off-by: Sandro Bonazzola <sbonazzo@redhat.com>