### PR TITLE
github actions: update action versions to current

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -30,12 +30,10 @@ jobs:
         run: |
           dnf -y install git jq wget rpmlint
 
-      # https://github.com/actions/checkout#checkout-pull-request-head-commit-instead-of-merge-commit
       - name: checkout sources (PR head, not the PR merge)
-        uses: actions/checkout@v2
+        uses: ovirt/checkout-action@main
         with:
           fetch-depth: 20
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: run automation/check.sh
         env:

--- a/.github/workflows/comment-to-build-pr.yaml
+++ b/.github/workflows/comment-to-build-pr.yaml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: checkout the repo
-        uses: actions/checkout@v2
+        uses: ovirt/checkout-action@main
 
       - name: checkout the PR
         env:
@@ -63,7 +63,7 @@ jobs:
             --rebuild exported-artifacts/ovirt-engine-nodejs-modules*.src.rpm
 
       - name: upload artifacts
-        uses: ovirt/upload-rpms-action@v2
+        uses: ovirt/upload-rpms-action@main
         with:
           directory: exported-artifacts/
 

--- a/ovirt-engine-nodejs-modules.spec
+++ b/ovirt-engine-nodejs-modules.spec
@@ -1,5 +1,5 @@
 Name: ovirt-engine-nodejs-modules
-Version: 2.3.14
+Version: 2.3.15
 Release: 1%{?dist}
 Summary: Node.js modules required to build oVirt JavaScript applications
 Group: Virtualization/Management
@@ -50,6 +50,10 @@ install -m 755 `find . -maxdepth 1 -name 'yarn-*.js' -exec basename {} \;` %{des
 %{_datadir}/%{name}
 
 %changelog
+* Wed Nov 30 2022 Scott J Dickerson <sdickers@redhat.com> - 2.3.15-1
+  - github actions: update action versions to current
+  - remove stale preseeds
+
 * Tue Nov 22 2022 Sharon Gratch <sgratch@redhat.com> - 2.3.14-1
   - add preseed for https://github.com/oVirt/ovirt-web-ui/pull/1638
   - remove stale preseeds

--- a/pre-seeds.list.mjs
+++ b/pre-seeds.list.mjs
@@ -15,7 +15,6 @@ export default {
     },
     folder: '/',
     pr: [
-      73,
     ]
   },
 
@@ -26,7 +25,6 @@ export default {
     },
     folder: '/',
     pr: [
-      1638,
     ]
   },
 


### PR DESCRIPTION
Upgrade to currently supported versions of actions used in `check.yaml` and `comment-to-build-pr.yaml`.

Ref: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

Signed-off-by: Scott J Dickerson <sdickers@redhat.com>